### PR TITLE
Add forward slash as a valid charcater in variable names

### DIFF
--- a/BitBake.sublime-syntax
+++ b/BitBake.sublime-syntax
@@ -55,7 +55,7 @@ contexts:
         pop: true
 
   variable_assignments:
-    - match: '^\s*(?:(export)\s+)?([\w\-]+(?:\${[\w\-]+})?)(\[\w+\])?(\-\w+)?(?=\s*{{operators_assignment}})'
+    - match: '^\s*(?:(export)\s+)?([\w\-\/]+(?:\${[\w\-]+})?)(\[\w+\])?(\-\w+)?(?=\s*{{operators_assignment}})'
       captures:
         1: storage.modifier.bitbake
         2: variable.other.bitbake


### PR DESCRIPTION
some varible assignmens like virtual packages have a '/' in their name.
This adds '/' as a valid charcater in variable names so this no longer
shows up as a syntax error.

Note, I haven't done any syntax work in Sublime before, so please let me know if I screwed anything up.